### PR TITLE
Some light reconfiguring!

### DIFF
--- a/apps/portal/src/app/layout.tsx
+++ b/apps/portal/src/app/layout.tsx
@@ -10,21 +10,21 @@ import { authSlice } from "redux-store/reducers";
 const openSans = Open_Sans({ subsets: ["latin"] });
 
 export default function RootLayout({
-	children,
+  children,
 }: {
-	children: React.JSX.Element;
+  children: React.JSX.Element;
 }) {
-	useEffect(() => {
-		const reduxState = getReduxStateFromLocalstorage();
-		if (reduxState) {
-			store.dispatch(authSlice.actions.hydrate(reduxState.auth));
-		}
-	}, []);
-	return (
-		<html lang="en">
-			<Providers>
-				<body className={openSans.className}>{children}</body>
-			</Providers>
-		</html>
-	);
+  useEffect(() => {
+    const reduxState = getReduxStateFromLocalstorage();
+    if (reduxState) {
+      store.dispatch(authSlice.actions.hydrate(reduxState.auth));
+    }
+  }, []);
+  return (
+    <html lang="en">
+      <Providers>
+        <body className={openSans.className}>{children}</body>
+      </Providers>
+    </html>
+  );
 }

--- a/apps/portal/src/utils/providers.tsx
+++ b/apps/portal/src/utils/providers.tsx
@@ -5,5 +5,5 @@ import { Provider } from "react-redux";
 import { store } from "redux-store/store";
 
 export const Providers = ({ children }: { children: React.JSX.Element }) => {
-	return <Provider store={store}>{children}</Provider>;
+  return <Provider store={store}>{children}</Provider>;
 };

--- a/packages/redux-store/package.json
+++ b/packages/redux-store/package.json
@@ -1,24 +1,40 @@
 {
-	"name": "redux-store",
-	"version": "0.0.0",
-	"main": "./index.tsx",
-	"types": "./index.tsx",
-	"license": "MIT",
-	"scripts": {
-		"lint": "eslint .",
-		"generate:component": "turbo gen react-component"
-	},
-	"devDependencies": {
-		"@turbo/gen": "^1.10.12",
-		"@types/node": "^20.10.6",
-		"@types/react": "^18.2.46",
-		"@types/react-dom": "^18.2.18",
-		"eslint-config-custom": "workspace:*",
-		"tsconfig": "workspace:*",
-		"typescript": "^4.5.2"
-	},
-	"dependencies": {
-		"@reduxjs/toolkit": "^1.9.5",
-		"react": "^18.2.0"
-	}
+  "name": "redux-store",
+  "version": "0.0.0",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./index.tsx",
+      "default": "./index.tsx"
+    },
+    "./actions": {
+      "types": "./actions.ts",
+      "default": "./actions.ts"
+    },
+    "./reducers": {
+      "types": "./reducers/index.ts",
+      "default": "./reducers/index.ts"
+    },
+    "./store": {
+      "types": "./store.ts",
+      "default": "./store.ts"
+    }
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "generate:component": "turbo gen react-component"
+  },
+  "devDependencies": {
+    "@turbo/gen": "^1.10.12",
+    "@types/node": "^20.10.6",
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*",
+    "typescript": "^4.5.2"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "^1.9.5",
+    "react": "^18.2.0"
+  }
 }

--- a/packages/redux-store/tsconfig.json
+++ b/packages/redux-store/tsconfig.json
@@ -6,11 +6,11 @@
     "paths": {
       "@redux-store/*": ["src/*"]
     },
-    "module": "commonjs",
+    "module": "ESNext",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
+    "isolatedModules": true
   },
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -1,25 +1,25 @@
 {
-	"$schema": "https://json.schemastore.org/tsconfig",
-	"display": "Default",
-	"compilerOptions": {
-		"baseUrl": ".",
-		"composite": false,
-		"declaration": true,
-		"declarationMap": true,
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"inlineSources": false,
-		"isolatedModules": true,
-		"moduleResolution": "node",
-		"noUnusedLocals": false,
-		"noUnusedParameters": false,
-		"preserveWatchOutput": true,
-		"skipLibCheck": true,
-		"strict": true,
-		"strictNullChecks": true,
-      "paths": {
-        "react": ["node_modules/@types/react"]
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Default",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "moduleResolution": "Bundler",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "paths": {
+      "react": ["node_modules/@types/react"]
     }
-	},
-	"exclude": ["node_modules"]
+  },
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Two important changes here!

1. Using `"moduleResolution": "Bundler"` or `"moduleResolution": "ESNext"`: These are the only two options you want to use in modern TypeScript, depending on if you are using a bundler for your applications or not. In your case you're using a bundler for your applications, so we'll use `Bundler`.
2. Using the `"exports"` key to configure multiple entrypoints to a package: When you define `main` and `types` in `package.json`, you're saying "this package can only be accessed using `import {} from "package-name"`. Instead you want to be able to do more entrypoints, like `import {} from "package-name/store"`, so you'll want to use the `exports` key for that.

Hopefully that helps! The general theme here is: TypeScript configuration. I'll admit that I'm not sure why VSCode and local builds weren't showing errors. They should have been! The Vercel build was giving you the correct error messages while everyone else was lying. 😄 

Note: Sorry about the indents on the PR diff. Prettier did it's thing. 😄 